### PR TITLE
Updated Microsoft learn first party app doc uri

### DIFF
--- a/src/Export-MicrosoftApps.ps1
+++ b/src/Export-MicrosoftApps.ps1
@@ -31,7 +31,7 @@ param (
 
 function GetAppsFromMicrosoftLearnDoc() {
     Write-Debug "Retrieving apps from Microsoft Learn doc"
-    $msLearnFirstPartyAppDocUri = "https://github.com/MicrosoftDocs/SupportArticles-docs/blob/main/support/entra/entra-id/governance/verify-first-party-apps-sign-in.md"
+    $msLearnFirstPartyAppDocUri = "https://raw.githubusercontent.com/MicrosoftDocs/SupportArticles-docs/refs/heads/main/support/entra/entra-id/governance/verify-first-party-apps-sign-in.md"
     $mdContent = (Invoke-WebRequest -Uri $msLearnFirstPartyAppDocUri).Content
     $lines = $mdContent -split [Environment]::NewLine
     $tableIndex = 0

--- a/src/Export-MicrosoftApps.ps1
+++ b/src/Export-MicrosoftApps.ps1
@@ -31,7 +31,7 @@ param (
 
 function GetAppsFromMicrosoftLearnDoc() {
     Write-Debug "Retrieving apps from Microsoft Learn doc"
-    $msLearnFirstPartyAppDocUri = "https://raw.githubusercontent.com/MicrosoftDocs/SupportArticles-docs/main/support/azure/entra/entra-id/governance/verify-first-party-apps-sign-in.md"
+    $msLearnFirstPartyAppDocUri = "https://github.com/MicrosoftDocs/SupportArticles-docs/blob/main/support/entra/entra-id/governance/verify-first-party-apps-sign-in.md"
     $mdContent = (Invoke-WebRequest -Uri $msLearnFirstPartyAppDocUri).Content
     $lines = $mdContent -split [Environment]::NewLine
     $tableIndex = 0


### PR DESCRIPTION
The script could no longer be executed without errors. This was due to an orphaned link that was used. This was replaced by a new link.